### PR TITLE
#190, makes start/end dates configurable

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -6,5 +6,7 @@
 		"database":"sea_ice_atlas",
 		"host":"localhost",
 		"port":30303
-	}
+	},
+	"startYear": 1853,
+	"endYear": 2012
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -6,6 +6,15 @@ window.client = {
     Collections: {},
     Views: {},
     Routers: {},
+
+    // Application-wide configuration for client-side code.
+    // Note, also update the server-side configuration (in ~/config.json) when changing these values.
+    config: {
+    	// Used for driving GUI for date range for available data.
+    	startYear: 1853,
+    	endYear: 2012
+    },
+
     init: function () {
         window.appRouter = new client.Routers.ApplicationRouter();
 

--- a/src/scripts/models/Map.js
+++ b/src/scripts/models/Map.js
@@ -6,11 +6,14 @@ client.Models = client.Models || {};
 	'use strict';
 
 	client.Models.MapModel = Backbone.Model.extend({
-		defaults: {
-			month: '01',
-			year: 1953,
-			concentration: 30
+		defaults: function() {
+			return {
+				month: '01',
+				year: client.config.startYear,
+				concentration: 30
+			};
 		}
-	});
+	}
+	);
 
 })();

--- a/src/scripts/views/Controls.js
+++ b/src/scripts/views/Controls.js
@@ -15,7 +15,7 @@ client.Views.MapControlsView = Backbone.View.extend({
 
 		this.$el.html(this.template());
 
-		var range = _.range(1953, 2013);
+		var range = _.range(client.config.startYear, client.config.endYear + 1);
 		var yearSelect = $(this.$el.find('select.year')[0]);
 		_.each(range, function(year) {
 			yearSelect.append($('<option>', {

--- a/src/scripts/views/ThresholdGraphic.js
+++ b/src/scripts/views/ThresholdGraphic.js
@@ -51,14 +51,19 @@ drawGraphic: function() {
 
 	var tasks = []
 	var datesUsed = {};
-	var dateIndex = 1953;
+	var dateIndex = client.config.startYear;
+
+	// Used below for ensuring we're displaying the final bar which spans to the next year.
+	var rolloverYear = client.config.endYear + 1;
+	
 	_.each(this.sourceData, function(e,i,l){
+
 		var startDate = moment(e[0],'YYYY-MM-DD').toDate()
 		var endDate = moment(e[1],'YYYY-MM-DD').toDate()
 		var taskName = startDate.getFullYear()
 
-		startDate.setFullYear(2013)
-		endDate.setFullYear(2013)
+		startDate.setFullYear(rolloverYear)
+		endDate.setFullYear(rolloverYear)
 		var rowObject = {
 			startDate:startDate, endDate:endDate, taskName:taskName, status:'RUNNING'
 		};
@@ -68,10 +73,10 @@ drawGraphic: function() {
 		datesUsed[taskName].push(rowObject);
 	})
 
-	for(var i = 2012; i >= 1953; i-- ) {
+	for(var i = client.config.endYear; i >= client.config.startYear; i-- ) {
 		if(!(datesUsed[i])) {
-			var start = moment('01-01-2013','MM-DD-YYYY').toDate()
-			var end = moment('01-01-2013','MM-DD-YYYY').toDate()
+			var start = moment('01-01-' + rolloverYear,'MM-DD-YYYY').toDate()
+			var end = moment('01-01-' + rolloverYear,'MM-DD-YYYY').toDate()
 			tasks.push({startDate:start, endDate:end, taskName:i, status:'RUNNING'})
 		}
 


### PR DESCRIPTION
To use this change, you need to drop some configuration into 2 places: the config.json and the app/main.js.

We can track the info in main.js in source control and just update it as the end year changes.  Config.json needs to be updated manually.

Most GUI controls are OK with this, unexpectedly, but some tweaking around various things is needed.  The query that drives Highcharts doesn't appear to return years/values where there's no information (which, we may need to make sure that's not an issue of its own if we have gappy/spotty data) so it's unclear how or if that one will be nuked.

The d3 stuff does surprisingly OK but needs formatting changes.
