### PR TITLE
Attach Google analytics code

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,9 +12,10 @@ var express = require('express')
 
 var app = express();
 
-// Establish config file connections, add it to the app
+// Establish config file connections, add it to the app + expose to templates
 conf.file({ file: './config.json' });
 app.set('config', conf);
+app.locals.config = conf.get();
 
 app.configure(function(){
   app.set('port', conf.get('port'));

--- a/config.json.example
+++ b/config.json.example
@@ -6,5 +6,6 @@
 		"database":"sea_ice_atlas",
 		"host":"localhost",
 		"port":30303
-	}
+	},
+	"google_analytics_token":false
 }

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -75,3 +75,13 @@ html
 			p	The University of Alaska Fairbanks is an affirmative action/equal opportunity employer and educational institution.&nbsp;&nbsp;&nbsp;
 
 		script(src='/js/client.js')
+		unless false === config.google_analytics_token
+			script.
+				var _gaq = _gaq || [];
+				_gaq.push(['_setAccount', '#{config.google_analytics_token}']);
+				_gaq.push(['_trackPageview']);
+				(function() {
+					var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+					ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+				})();


### PR DESCRIPTION
Added new configuration option, "google_analytics_token".  For development, this should be set to boolean false, as in the config.json.example file; for production, it should be set to a string which is the analytics token for the site.
