### PR TITLE
removes dual client/server configuration for start/end year

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem install compass
 brew install node
 ```
 
-### Installation
+### Installation & configuration
 
 ```bash
 git clone git@github.com:ua-snap/sea-ice-atlas.git
@@ -34,7 +34,32 @@ The application also needs a configuration file set up.  From a fresh checkout:
 cp config.json.example config.json
 ```
 
-Then, edit the ```config.json``` file to specify port & database connection.
+Then, edit the ```config.json``` file to specify port & database connection.  The configuration file is documented below:
+
+```javascript
+{
+	// Port on which the application will run.
+	"port": 3000,
+
+	// Database connection information.
+	"database": {
+		"user":"sea_ice_atlas_user",
+		"password":"example",
+		"database":"sea_ice_atlas",
+		"host":"localhost",
+		"port":30303
+	},
+
+	// Analytics token.
+	// If set to Boolean false, Google analytics is not attached,
+	// otherwise should be set to a string with the property ID token.
+	"google_analytics_token":false,
+
+	// Start and end year ranges for the data.
+	"startYear":1853,
+	"endYear":2012
+}
+```
 
 ### Building the project
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,14 +7,6 @@ window.client = {
     Views: {},
     Routers: {},
 
-    // Application-wide configuration for client-side code.
-    // Note, also update the server-side configuration (in ~/config.json) when changing these values.
-    config: {
-    	// Used for driving GUI for date range for available data.
-    	startYear: 1853,
-    	endYear: 2012
-    },
-
     init: function () {
         window.appRouter = new client.Routers.ApplicationRouter();
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -85,3 +85,8 @@ html
 					ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
 					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 				})();
+
+		script.
+			window.client.config = window.client.config || {};
+			window.client.config.startYear = #{config.startYear};
+			window.client.config.endYear = #{config.endYear};


### PR DESCRIPTION
Before, the start/end year configs were in two places -- confusing/error-prone.  fixed by having the config.json interpolate into the jade layout template.
