### PR TITLE
Fix up GUI interactions with animation start/stop

### DIFF
--- a/src/less/style.less
+++ b/src/less/style.less
@@ -426,8 +426,8 @@ p {
 
 	#legend {
 		position: absolute;
-		bottom: 20px;
-		left: 595px;
+		bottom: 22px;
+		right: 8px;
 		width: 250px;
 		z-index: 1000;
 	}

--- a/src/scripts/models/Animation.js
+++ b/src/scripts/models/Animation.js
@@ -104,6 +104,7 @@ function parseToDate(idx) {
 				Q.allSettled(this.layerBuffer).then(_.bind(function startUpdater(results) {
 					this.view.hideBuffering();
 					this.startPlaying();
+					this.view.enableControls();
 				}, this));
 			}, this), 1000);
 

--- a/src/scripts/templates/MapAnimator.ejs
+++ b/src/scripts/templates/MapAnimator.ejs
@@ -9,7 +9,7 @@
 			<small><em>e.g. Jan 1953, Feb 1953, Mar 1953&nbsp;&hellip;</em></small>
 
 			<div class="btn-group">
-				<button class="btn btn-default btn-primary btn-xs" id="sequentialAnimationPlay"><span class="glyphicon glyphicon-play"></span></button>
+				<button class="btn btn-primary btn-xs play" id="sequentialAnimationPlay"><span class="glyphicon glyphicon-play"></span></button>
 				<button class="btn btn-default btn-xs" id="sequentialAnimationPause"><span class="glyphicon glyphicon-pause"></span></button>
 			</div>
 		</div>
@@ -20,7 +20,7 @@
 			<small><em>e.g. Jan 1953, Jan 1954, Jan 1955&nbsp;&hellip;</em></small>
  
 			<div class="btn-group">
-				<button class="btn btn-default btn-primary btn-xs" id="monthlyAnimationPlay"><span class="glyphicon glyphicon-play"></span></button>
+				<button class="btn btn-primary btn-xs play" id="monthlyAnimationPlay"><span class="glyphicon glyphicon-play"></span></button>
 				<button class="btn btn-default btn-xs" id="monthlyAnimationPause"><span class="glyphicon glyphicon-pause"></span></button>
 			</div>
 		</div>

--- a/src/scripts/templates/application.ejs
+++ b/src/scripts/templates/application.ejs
@@ -10,11 +10,9 @@
 				</a>
 				<a id="mapControls" class="list-group-item active" style="display: none"></a>
 				<a id="concentrationGraphControls" class="list-group-item" style="display: none">
-					<!--<h4 class="list-group-item-header">Graph</h4>-->
 					<span class="glyphicon glyphicon-circle-arrow-down pull-right"></span><p class="jumptograph"></p>
 				</a>
 				<a id="thresholdGraphicControls" class="list-group-item" style="display: none;">
-					<!--<h4 class="list-group-item-header">Visualization</h4>-->
 					<span class="glyphicon glyphicon-circle-arrow-down pull-right"></span><p class="jumptograph">Explore ice open/close dates for this location</p>
 				</a>
 				<a id="mapAnimationControls" class="list-group-item" style="display: none"></a>

--- a/src/scripts/views/Animation.js
+++ b/src/scripts/views/Animation.js
@@ -2,10 +2,14 @@
 'use strict';
 
 client.Views.MapAnimatorView = Backbone.View.extend({
+
+	isPlaying: false,
+
 	initialize: function() {
 
 		_.bindAll(this, 'play', 'pause', 'setMode', 'playSequentialMode', 'playMonthlyMode',
-			'render', 'showLayer', 'loadLayer', 'hideLayer', 'showBuffering', 'hideBuffering');
+			'render', 'showLayer', 'loadLayer', 'hideLayer', 'showBuffering', 'hideBuffering',
+			'disableControls', 'enableControls', 'resetControlsState');
 		// Set up some shortcuts
 		this.map = this.options.mapView.map;
 		this.model = this.options.model;
@@ -21,7 +25,7 @@ client.Views.MapAnimatorView = Backbone.View.extend({
 	promises: {},
 
 	events: {
-		'click button' : 'focus',
+		'click button.play' : 'focus',
 		'click #sequentialAnimationPlay' : 'playSequentialMode',
 		'click #sequentialAnimationPause' : 'pause',
 		'click #monthlyAnimationPlay' : 'playMonthlyMode',
@@ -35,11 +39,27 @@ client.Views.MapAnimatorView = Backbone.View.extend({
 		window.appRouter.setMapMode('animation');
 	},
 
+	// Remove map layer and clear any pending promises.
 	resetLayers: function() {
 		var k = this.map.getLayersBy('isBaseLayer', false);
 		_.each(k, _.bind(function(e, i, l) {
 			this.map.removeLayer(e);
 		}, this));
+		this.promises = {};
+	},
+
+	// To prevent the user from bouncing on the start/stop buttons, which can mess with the state.
+	disableControls: function() {
+		this.$el.find('button').attr('disabled', 'true');
+	},
+	enableControls: function() {
+		this.$el.find('button').attr('disabled', false);
+	},
+	resetControlsState: function() {
+		$('#monthlyAnimationPlay').removeClass('btn-success').addClass('btn-primary');
+		$('#monthlyAnimationPause').removeClass('btn-warning').addClass('btn-default');
+		$('#sequentialAnimationPlay').removeClass('btn-success').addClass('btn-primary');
+		$('#sequentialAnimationPause').removeClass('btn-warning').addClass('btn-default');
 	},
 
 	setMode: _.debounce(function(mode) {
@@ -47,21 +67,37 @@ client.Views.MapAnimatorView = Backbone.View.extend({
 	}, 1000, true),
 
 	play: _.debounce(function() {
+		if( true === this.isPlaying ) {
+			this.model.stop();
+		}
 		this.resetLayers();
 		this.model.start();
+		this.disableControls();
+		this.isPlaying = true;
 	}, 1000, true),
 
 	pause: function() {
-		this.model.stop();
+		if( true === this.isPlaying ) {
+			this.isPlaying = false;
+			this.resetControlsState();
+			this.model.stop();
+			this.enableControls();
+		}
 	},
 
 	playSequentialMode: function() {
 		this.setMode('sequential');
+		this.resetControlsState();
+		$('#sequentialAnimationPlay').removeClass('btn-primary').addClass('btn-success');
+		$('#sequentialAnimationPause').removeClass('btn-default').addClass('btn-warning');
 		this.play();
 	},
 
 	playMonthlyMode: function() {
 		this.setMode('monthly');
+		this.resetControlsState();
+		$('#monthlyAnimationPlay').removeClass('btn-primary').addClass('btn-success');
+		$('#monthlyAnimationPause').removeClass('btn-default').addClass('btn-warning');
 		this.play();
 	},
 
@@ -103,7 +139,12 @@ client.Views.MapAnimatorView = Backbone.View.extend({
 
 		// When the "loadend" event is triggered on the layer, resolve its initial loading promise.
 		this.layers[this.model.layers[layerIndex]].events.register('loadend', this, function(layer) {
-			this.promises[this.model.layers[layer.object.layerIndex]].resolve(layer);
+			
+			// These layers can be undefined if the animations are swapped out while in progress.
+			if( false === _.isUndefined( this.promises[this.model.layers[layer.object.layerIndex]] ) ) {
+				this.promises[this.model.layers[layer.object.layerIndex]].resolve(layer);	
+			}
+			
 		});
 		
 		// Map loading only starts happening when the addLayer method is invoked.


### PR DESCRIPTION
- Clicking Pause button when in MapMode (not AnimationMode) no longer removes the visible overlay
- Play / Pause Buttons are enabled/disabled to prevent user from starting two overlapping animation sequences
- Colored the buttons, used standard Bootstrap classes: btn-success and btn-warning for playing/pause, respectively.  Imperfect but OK I think.
- Pulls the map legend inside the Map when browser width is reduced (it was standing-off-from-left, which made it stick out in some cases).
